### PR TITLE
Hot fix notifications

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="-1725245311">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Tests" value="360" />
+                  <entry key="vivo V2145" value="120" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-570935173">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Tests" value="360" />
+                  <entry key="vivo V2145" value="120" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -64,6 +64,12 @@
       <SelectionState runConfigName="PetActivity">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="GetMealsByPetIdUseCaseTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="itMustReturnAList()">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "com.maverickapps.nutripet"
         minSdk = 24
         targetSdk = 35
-        versionCode = 10
-        versionName = "0.73"
+        versionCode = 11
+        versionName = "0.74"
 
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/androidTest/java/com/maverickapps/nutripet/petsFeature/domain/mealsUseCases/GetMealsByPetIdUseCaseTest.kt
+++ b/app/src/androidTest/java/com/maverickapps/nutripet/petsFeature/domain/mealsUseCases/GetMealsByPetIdUseCaseTest.kt
@@ -7,7 +7,9 @@ import com.maverickapps.nutripet.core.data.database.AppDatabase
 import com.maverickapps.nutripet.core.data.database.dao.MealDao
 import com.maverickapps.nutripet.features.events.domain.useCase.CheckDayChangedUseCase
 import com.maverickapps.nutripet.features.pets.data.repositories.MealsRepository
-import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.GetMealsUseCase
+import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.EditMealUseCase
+import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.GetDailyMealsUseCase
+import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.GetMealsByPetIdUseCase
 import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.UpdateMealsDayChangedUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -19,16 +21,20 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class GetMealsUseCaseTest {
+class GetMealsByPetIdUseCaseTest {
 
     @MockK
     private lateinit var checkDayChangedUseCase: CheckDayChangedUseCase
+
+    @MockK
+    private lateinit var editMealUseCase: EditMealUseCase
 
     private lateinit var mealDao: MealDao
     private lateinit var db: AppDatabase
     private lateinit var mealsRepository: MealsRepository
     private lateinit var updateMealsDayChangedUseCase: UpdateMealsDayChangedUseCase
-    private lateinit var getMealsUseCase: GetMealsUseCase
+    private lateinit var getMealsByPetIdUseCase: GetMealsByPetIdUseCase
+    private lateinit var getDailyMealsUseCase: GetDailyMealsUseCase
 
     @Before
     fun setUp() {
@@ -39,8 +45,9 @@ class GetMealsUseCaseTest {
             AppDatabase::class.java).allowMainThreadQueries().build()
         mealDao = db.getMealDao()
         mealsRepository = MealsRepository(mealDao)
-        updateMealsDayChangedUseCase = UpdateMealsDayChangedUseCase(mealsRepository)
-        getMealsUseCase = GetMealsUseCase(mealsRepository, checkDayChangedUseCase, updateMealsDayChangedUseCase)
+        getDailyMealsUseCase = GetDailyMealsUseCase(mealsRepository)
+        updateMealsDayChangedUseCase = UpdateMealsDayChangedUseCase(getDailyMealsUseCase,editMealUseCase)
+        getMealsByPetIdUseCase = GetMealsByPetIdUseCase(mealsRepository)
     }
 
     @After
@@ -55,7 +62,7 @@ class GetMealsUseCaseTest {
             coEvery { checkDayChangedUseCase()} returns true
 
             //When
-            val list = getMealsUseCase(1)
+            val list = getMealsByPetIdUseCase(1)
 
             //Must
             assert(list.isEmpty())
@@ -70,11 +77,11 @@ class GetMealsUseCaseTest {
             coEvery { checkDayChangedUseCase()} returns false
 
             //When
-            val list = getMealsUseCase(1)
+            val list = getMealsByPetIdUseCase(1)
 
             //Must
             println(list.toString())
-            assert(list.isNotEmpty() && list.size == 2)
+            assert(list.isNotEmpty())
         }
 
     }

--- a/app/src/main/java/com/maverickapps/nutripet/core/data/database/dao/MealDao.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/core/data/database/dao/MealDao.kt
@@ -21,9 +21,6 @@ interface MealDao {
     @Query("DELETE FROM meal_table")
     suspend fun clearAllMeals()
 
-    @Query("DELETE FROM meal_table WHERE is_daily_meal = 0")
-    suspend fun clearNotDailyMeals()
-
     @Query("SELECT * FROM meal_table WHERE is_daily_meal = 1")
     suspend fun getDailyMeals(): List<MealEntity>
 

--- a/app/src/main/java/com/maverickapps/nutripet/core/ui/components/dialogs/updateDialogs/UpdatesNotesDialog.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/core/ui/components/dialogs/updateDialogs/UpdatesNotesDialog.kt
@@ -40,13 +40,13 @@ fun UpdateNotesDialog(
             onDismissRequest = onDismiss,
             title = {
                 Box {
-                    Text(text = "🔔 Novedades de esta versión (0.7.3)",
+                    Text(text = "🔔 Novedades de esta versión (0.7.4)",
                         style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.Bold,
                         color = SecondaryDarkest,
                         modifier = Modifier.blur(3.dp).padding(3.dp)
                     )
-                    Text(text = "🔔 Novedades de esta versión (0.7.3)",
+                    Text(text = "🔔 Novedades de esta versión (0.7.4)",
                         style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.Bold,
                         color = Primary,
@@ -75,35 +75,19 @@ fun UpdateNotesDialog(
                         Text(buildAnnotatedString {
                             withStyle(style = SpanStyle(color = SecondaryDarkest,
                                 fontWeight = FontWeight.Bold)){
-                                append("Notificaciones inteligentes: ")
+                                append("Notificaciones que no saltaban: ")
                             }
                             withStyle(style = SpanStyle(color = SecondaryDarkest)){
-                                append("Ya no se mostrarán notificaciones de comidas que el " +
-                                        "usuario ya registró como consumidas. \uD83D\uDC49 " +
-                                        "Evitamos interrupciones innecesarias y enfocamos las " +
-                                        "alertas en lo importante")
+                                append("Se corrigió un error que impedía que las notificaciones " +
+                                        "se mostraran correctamente al día siguiente cuando se" +
+                                        " habían cancelado por registrar una comida como " +
+                                        "consumida. Ahora las alertas se restablecen como " +
+                                        "corresponde cada nuevo día.")
                             }
                         })
-                    }
-                    Spacer(Modifier.height(MaterialTheme.dimens.extraSmall3))
-                    BulletPoint {
-                        Text(buildAnnotatedString {
-                            withStyle(style = SpanStyle(color = SecondaryDarkest,
-                                fontWeight = FontWeight.Bold)){
-                                append("Corrección de cierre inesperado al registrar comidas: ")
-                            }
-                            withStyle(style = SpanStyle(color = SecondaryDarkest)){
-                                append("Se ha solucionado un error crítico que provocaba que la" +
-                                        " app se cerrara automáticamente al marcar una comida" +
-                                        " como consumida. \uD83D\uDC49 Ahora los registros se " +
-                                        "procesan correctamente, sin interrupciones ni pérdidas " +
-                                        "de progreso.")
-                            }
-                        })
-
                     }
                     Spacer(Modifier.height(MaterialTheme.dimens.small1))
-                    Box{
+                    /*Box{
                         Text("Mejoras ✨",
                             style = MaterialTheme.typography.headlineSmall,
                             fontWeight = FontWeight.Bold,
@@ -132,7 +116,7 @@ fun UpdateNotesDialog(
                                         "falta acertar el ícono: más rápido, más cómodo.")
                             }
                         })
-                    }
+                    }*/
                 }
             },
             confirmButton = {

--- a/app/src/main/java/com/maverickapps/nutripet/features/events/domain/dayChangerEvents/receiver/DayChanger.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/features/events/domain/dayChangerEvents/receiver/DayChanger.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.maverickapps.nutripet.features.notifications.domain.useCase.RefreshScheduleNotificationsUseCase
+import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.UpdateMealsDayChangedUseCase
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,12 +15,14 @@ import javax.inject.Inject
 class DayChanger  : BroadcastReceiver() {
 
     @Inject lateinit var refreshScheduleNotificationsUseCase: RefreshScheduleNotificationsUseCase
+    @Inject lateinit var updateMealsDayChangedUseCase: UpdateMealsDayChangedUseCase
 
     companion object {
         const val DAY_CHANGE_EVENT_ID = 3001
     }
     override fun onReceive(context: Context, intent: Intent) {
         CoroutineScope(Dispatchers.IO).launch {
+            updateMealsDayChangedUseCase()
             refreshScheduleNotificationsUseCase()
         }
     }

--- a/app/src/main/java/com/maverickapps/nutripet/features/events/domain/dayChangerEvents/receiver/DayChanger.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/features/events/domain/dayChangerEvents/receiver/DayChanger.kt
@@ -3,6 +3,8 @@ package com.maverickapps.nutripet.features.events.domain.dayChangerEvents.receiv
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.util.Log
+import com.maverickapps.nutripet.features.events.domain.useCase.schedule.ScheduleDayChangerUseCase
 import com.maverickapps.nutripet.features.notifications.domain.useCase.RefreshScheduleNotificationsUseCase
 import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.UpdateMealsDayChangedUseCase
 import dagger.hilt.android.AndroidEntryPoint
@@ -16,14 +18,17 @@ class DayChanger  : BroadcastReceiver() {
 
     @Inject lateinit var refreshScheduleNotificationsUseCase: RefreshScheduleNotificationsUseCase
     @Inject lateinit var updateMealsDayChangedUseCase: UpdateMealsDayChangedUseCase
+    @Inject lateinit var scheduleDayChangerUseCase: ScheduleDayChangerUseCase
 
     companion object {
         const val DAY_CHANGE_EVENT_ID = 3001
     }
     override fun onReceive(context: Context, intent: Intent) {
         CoroutineScope(Dispatchers.IO).launch {
+            Log.d("DayChanger", "Day changed")
             updateMealsDayChangedUseCase()
             refreshScheduleNotificationsUseCase()
+            scheduleDayChangerUseCase()
         }
     }
 }

--- a/app/src/main/java/com/maverickapps/nutripet/features/events/domain/dayChangerEvents/setter/DayChangerSetter.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/features/events/domain/dayChangerEvents/setter/DayChangerSetter.kt
@@ -32,10 +32,9 @@ class DayChangerSetter(
             && thisAlarmManager.canScheduleExactAlarms()
         ) {
             Log.d("DayChangerSetter", "Alarma programada para $time")
-            thisAlarmManager.setRepeating(
+            thisAlarmManager.setExactAndAllowWhileIdle(
                 AlarmManager.RTC_WAKEUP,
                 time,
-                AlarmManager.INTERVAL_DAY,
                 pendingIntent
             )
         }    }

--- a/app/src/main/java/com/maverickapps/nutripet/features/events/domain/useCase/schedule/ScheduleDayChangerUseCase.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/features/events/domain/useCase/schedule/ScheduleDayChangerUseCase.kt
@@ -1,14 +1,23 @@
 package com.maverickapps.nutripet.features.events.domain.useCase.schedule
 
+import android.icu.util.Calendar
 import com.maverickapps.nutripet.features.events.domain.dayChangerEvents.receiver.DayChanger
 import com.maverickapps.nutripet.features.events.domain.dayChangerEvents.scheduler.DayChangerScheduler
 import javax.inject.Inject
 
 class ScheduleDayChangerUseCase @Inject constructor(
     private val dayChangerScheduler: DayChangerScheduler
-)
-{
-    operator fun invoke(time: Long) {
+) {
+    operator fun invoke() {
+        val time = Calendar.getInstance()
+            .apply {
+                set(Calendar.HOUR_OF_DAY, 0)
+                set(Calendar.MINUTE, 0)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
+            .also { it.add(Calendar.DAY_OF_MONTH, 1) }.timeInMillis
+
         dayChangerScheduler.scheduleEvent(time, DayChanger.DAY_CHANGE_EVENT_ID)
     }
 }

--- a/app/src/main/java/com/maverickapps/nutripet/features/events/ui/viewmodel/EventsViewModel.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/features/events/ui/viewmodel/EventsViewModel.kt
@@ -1,8 +1,8 @@
 package com.maverickapps.nutripet.features.events.ui.viewmodel
 
 import android.app.Activity
-import android.icu.util.Calendar
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import com.maverickapps.nutripet.features.events.domain.useCase.exactAlarmPermissions.CheckExactAlarmPermissionUseCase
@@ -55,16 +55,8 @@ class EventsViewModel @Inject constructor(
     }
 
     fun scheduleDayChanger(){
-        val time = Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, 0)
-            set(Calendar.MINUTE, 0)
-            set(Calendar.SECOND, 0)
-            set(Calendar.MILLISECOND, 0)
-        }
-        if(time.timeInMillis < System.currentTimeMillis()){
-            time.add(Calendar.DAY_OF_MONTH, 1)
-        }
-        scheduleDayChangerUseCase(time.timeInMillis)
+        Log.d("EventsViewModel", "Scheduling day changer")
+        scheduleDayChangerUseCase()
     }
 
     suspend fun fetchMealEvents(){

--- a/app/src/main/java/com/maverickapps/nutripet/features/pets/data/repositories/MealsRepository.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/features/pets/data/repositories/MealsRepository.kt
@@ -28,10 +28,6 @@ class MealsRepository @Inject constructor(private val mealsDao: MealDao) {
         return mealsDao.getDailyMeals().map { it.toDomain() }
     }
 
-    suspend fun clearNotDailyMeals() {
-        mealsDao.clearNotDailyMeals()
-    }
-
     suspend fun addMealForAPet(meal: MealModel): Int {
         return mealsDao.addMealForAPet(meal.toDatabase()).toInt()
     }

--- a/app/src/main/java/com/maverickapps/nutripet/features/pets/domain/objectTasks/meal/useCase/GetDailyMealsUseCase.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/features/pets/domain/objectTasks/meal/useCase/GetDailyMealsUseCase.kt
@@ -3,9 +3,9 @@ package com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase
 import com.maverickapps.nutripet.features.pets.data.repositories.MealsRepository
 import javax.inject.Inject
 
-class GetMealsUseCase @Inject constructor(
+class GetDailyMealsUseCase @Inject constructor(
     private val mealsRepository: MealsRepository
 ) {
-    suspend operator fun invoke(petId: Int) = mealsRepository.getMealsByPetId(petId)
+    suspend operator fun invoke() = mealsRepository.getDailyMeals()
 
 }

--- a/app/src/main/java/com/maverickapps/nutripet/features/pets/domain/objectTasks/meal/useCase/GetMealsByPetIdUseCase.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/features/pets/domain/objectTasks/meal/useCase/GetMealsByPetIdUseCase.kt
@@ -3,9 +3,8 @@ package com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase
 import com.maverickapps.nutripet.features.pets.data.repositories.MealsRepository
 import javax.inject.Inject
 
-class GetMealsUseCase @Inject constructor(
+class GetMealsByPetIdUseCase @Inject constructor(
     private val mealsRepository: MealsRepository
 ) {
     suspend operator fun invoke(petId: Int) = mealsRepository.getMealsByPetId(petId)
-
 }

--- a/app/src/main/java/com/maverickapps/nutripet/features/pets/domain/objectTasks/meal/useCase/UpdateMealsDayChangedUseCase.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/features/pets/domain/objectTasks/meal/useCase/UpdateMealsDayChangedUseCase.kt
@@ -1,20 +1,19 @@
 package com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase
 
-import com.maverickapps.nutripet.features.pets.data.repositories.MealsRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
 
 class UpdateMealsDayChangedUseCase @Inject constructor(
-    private val mealsRepository: MealsRepository
+    private val getDailyMealsUseCase: GetDailyMealsUseCase,
+    private val editMealUseCase: EditMealUseCase
 ) {
     suspend operator fun invoke() {
-        mealsRepository.clearNotDailyMeals()
-        val dailyMeals = mealsRepository.getDailyMeals()
+        val dailyMeals = getDailyMealsUseCase()
         coroutineScope {
             for (meal in dailyMeals) {
                val mealEditing = async {
-                    mealsRepository.editMeal(meal.copy(mealState = 1))
+                    editMealUseCase(meal.copy(mealState = 1))
                 }
                 mealEditing.await()
                 println("Meal ${meal.mealState} of ${meal.mealId} updated")

--- a/app/src/main/java/com/maverickapps/nutripet/features/pets/domain/objectTasks/meal/useCase/UpdateMealsDayChangedUseCase.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/features/pets/domain/objectTasks/meal/useCase/UpdateMealsDayChangedUseCase.kt
@@ -1,6 +1,5 @@
 package com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase
 
-import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
 
@@ -12,10 +11,7 @@ class UpdateMealsDayChangedUseCase @Inject constructor(
         val dailyMeals = getDailyMealsUseCase()
         coroutineScope {
             for (meal in dailyMeals) {
-               val mealEditing = async {
-                    editMealUseCase(meal.copy(mealState = 1))
-                }
-                mealEditing.await()
+                editMealUseCase(meal.copy(mealState = 1))
                 println("Meal ${meal.mealState} of ${meal.mealId} updated")
             }
         }

--- a/app/src/main/java/com/maverickapps/nutripet/features/pets/domain/otherTasks/useCase/GetPetsDetailsUseCase.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/features/pets/domain/otherTasks/useCase/GetPetsDetailsUseCase.kt
@@ -1,6 +1,6 @@
 package com.maverickapps.nutripet.features.pets.domain.otherTasks.useCase
 
-import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.GetMealsUseCase
+import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.GetMealsByPetIdUseCase
 import com.maverickapps.nutripet.features.pets.domain.objectTasks.pet.useCase.GetPetByIdUseCase
 import com.maverickapps.nutripet.features.pets.domain.objectTasks.petFood.useCase.GetFoodsByPetIdUseCase
 import kotlinx.coroutines.Dispatchers
@@ -10,7 +10,7 @@ import javax.inject.Inject
 
 class GetPetsDetailsUseCase @Inject constructor(
     private val getPetByIdUseCase: GetPetByIdUseCase,
-    private val getMealsUseCase: GetMealsUseCase,
+    private val getMealsByPetIdUseCase: GetMealsByPetIdUseCase,
     private val getFoodsByPetIdUseCase: GetFoodsByPetIdUseCase,
     private val calculateCaloriesUseCase: CalculateCaloriesUseCase
 ) {
@@ -18,7 +18,7 @@ class GetPetsDetailsUseCase @Inject constructor(
     suspend operator fun invoke(petId: Int) = withContext(Dispatchers.IO){
 
         val pet = async { getPetByIdUseCase(petId)}
-        val meals = async { getMealsUseCase(petId)}
+        val meals = async { getMealsByPetIdUseCase(petId)}
         val foods = async { getFoodsByPetIdUseCase(petId)}
         val calories = async { calculateCaloriesUseCase(pet.await())}
 

--- a/app/src/main/java/com/maverickapps/nutripet/features/pets/ui/viewmodel/DashboardViewModel.kt
+++ b/app/src/main/java/com/maverickapps/nutripet/features/pets/ui/viewmodel/DashboardViewModel.kt
@@ -8,7 +8,7 @@ import com.maverickapps.nutripet.features.pets.domain.objectTasks.food.useCase.G
 import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.model.MealModel
 import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.DeleteMealUseCase
 import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.EditMealUseCase
-import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.GetMealsUseCase
+import com.maverickapps.nutripet.features.pets.domain.objectTasks.meal.useCase.GetMealsByPetIdUseCase
 import com.maverickapps.nutripet.features.pets.domain.objectTasks.pet.model.PetModel
 import com.maverickapps.nutripet.features.pets.domain.objectTasks.pet.useCase.DeletePetUseCase
 import com.maverickapps.nutripet.features.pets.domain.objectTasks.pet.useCase.GetPetsUseCase
@@ -23,7 +23,7 @@ import javax.inject.Inject
 class DashboardViewModel @Inject constructor(
     private val getPetsUseCase: GetPetsUseCase,
     private val deletePetUseCase: DeletePetUseCase,
-    private val getMealsUseCase: GetMealsUseCase,
+    private val getMealsByPetIdUseCase: GetMealsByPetIdUseCase,
     private val editMealUseCase: EditMealUseCase,
     private val getFoodsUseCase: GetFoodUseCase,
     private val calculateCaloriesUseCase: CalculateCaloriesUseCase,
@@ -77,7 +77,7 @@ class DashboardViewModel @Inject constructor(
     }
     fun getMeals() {
         viewModelScope.launch {
-            val meals = getMealsUseCase(selectedPetId.value!!)
+            val meals = getMealsByPetIdUseCase(selectedPetId.value!!)
             getFoods(meals)
         }
     }


### PR DESCRIPTION
#73 FIX: notifications doesn't trigerr correctly after a meal consumption; Meal notification was cancelled but it doesn't get reseted the next day.

The usecase that should editmeals when the day change call directly editMeal function from the repository, ignoring the editMealUseCase and avoiding all the indirect notifications and events logic triggered after the call of that function

-Now the usecase edit meals through the propper usecase, reusing the notifications logic behind
-Now the dailymealsedit within the days is triggered with the broadcastreceiver that refresh all the events each day at 00:00 am
-It removes the DayChangerHandler as is not further needed